### PR TITLE
Add About Me section to homepage

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,9 +37,9 @@
         <h1>{{ title }}</h1>
     </div>
 
-    <section class="about-me"
+    <section class="about-me" aria-labelledby="about-me-heading"
         style="max-width:600px; margin:2rem auto; padding:1rem; background:#f9f9f9; border-radius:8px;">
-        <h2>About Me</h2>
+        <h2 id="about-me-heading">About Me</h2>
         <p>
             I am a recent graduate in Computer Science from Washington State University with a minor in Mathematics.
             My research spans robotics, machine learning, and AI safety, with a focus on reinforcement learning,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,5 +36,29 @@
         </div>
         <h1>{{ title }}</h1>
     </div>
+
+    <section class="about-me"
+        style="max-width:600px; margin:2rem auto; padding:1rem; background:#f9f9f9; border-radius:8px;">
+        <h2>About Me</h2>
+        <p>
+            I am a recent graduate in Computer Science from Washington State University with a minor in Mathematics.
+            My research spans robotics, machine learning, and AI safety, with a focus on reinforcement learning,
+            human-AI collaboration, and large language models.
+        </p>
+        <p>
+            I’ve conducted research at Carnegie Mellon University (HARP Lab) on hierarchical reward learning, Oregon
+            State University (CHARISMA Lab) on multi-robot navigation, and completed a software engineering
+            internship at Google (STEP Intern), where I built scalable data processing and visualization systems to
+            support internal analytics.
+        </p>
+        <p>
+            I am currently seeking full-time opportunities in AI/ML research and engineering while preparing to apply
+            for M.S. programs in Spring 2026.
+        </p>
+        <p>
+            Please feel free to reach out about research, collaboration, or any advice I can help with!
+        </p>
+    </section>
 </body>
+
 </html>


### PR DESCRIPTION
This pull request adds an "About Me" section to the homepage, featuring a detailed paragraph about my background, interests, and goals. The section is styled for clarity and readability.
Closes #2.

Please review and let me know if any changes are needed!