### PR TITLE
Add previous work experiences section with Jinja template loop

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 import os
 from flask import Flask, render_template, request
 from dotenv import load_dotenv
+from .data import work_experiences  # Import work experiences from data.py
 
 load_dotenv()
 app = Flask(__name__)
@@ -9,44 +10,6 @@ app = Flask(__name__)
 @app.route("/")
 def index():
     user = {"name": "Ethan Villalovoz"}
-    work_experiences = [
-        {
-            "role": "Production Engineering Fellow",
-            "company": "Meta x MLH",
-            "dates": "Summer 2025",
-            "location": "Remote USA",
-            "responsibilities": [
-                "Selected for the Meta x MLH Production Engineering Fellowship (acceptance rate < 2.5%), a 12-week program focused on Site Reliability Engineering (SRE), DevOps, and large-scale infrastructure."
-            ]
-        },
-        {
-            "role": "Robotics Institute Summer Scholar",
-            "company": "Carnegie Mellon University",
-            "dates": "Summer 2024",
-            "location": "Pittsburgh, Pennsylvania USA",
-            "responsibilities": [
-                "Developed hierarchical reward learning systems leveraging Bayesian inference and human feedback to align autonomous systems with human preferences and improve adaptability in dynamic settings."
-            ]
-        },
-        {
-            "role": "STEP Intern",
-            "company": "Google",
-            "dates": "Summer 2023",
-            "location": "Sunnyvale, California USA",
-            "responsibilities": [
-                "Optimized internal database processes with C++ and SQL, reducing runtime by 66% and enhancing data visualization through real-time dashboards and dynamic graphs."
-            ]
-        },
-        {
-            "role": "Robots in the Real World Researcher",
-            "company": "Oregon State University",
-            "dates": "Summer 2022",
-            "location": "Corvallis, Oregon USA",
-            "responsibilities": [
-                "Developed geometric features for multi-robot expressive motion, integrating performing arts techniques to enhance robot character and intelligence."
-            ]
-        }
-    ]
     return render_template(
         'index.html',
         title="MLH Fellow",

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,4 +9,48 @@ app = Flask(__name__)
 @app.route("/")
 def index():
     user = {"name": "Ethan Villalovoz"}
-    return render_template('index.html', title="MLH Fellow", url=os.getenv("URL"), user=user)
+    work_experiences = [
+        {
+            "role": "Production Engineering Fellow",
+            "company": "Meta x MLH",
+            "dates": "Summer 2025",
+            "location": "Remote USA",
+            "responsibilities": [
+                "Selected for the Meta x MLH Production Engineering Fellowship (acceptance rate < 2.5%), a 12-week program focused on Site Reliability Engineering (SRE), DevOps, and large-scale infrastructure."
+            ]
+        },
+        {
+            "role": "Robotics Institute Summer Scholar",
+            "company": "Carnegie Mellon University",
+            "dates": "Summer 2024",
+            "location": "Pittsburgh, Pennsylvania USA",
+            "responsibilities": [
+                "Developed hierarchical reward learning systems leveraging Bayesian inference and human feedback to align autonomous systems with human preferences and improve adaptability in dynamic settings."
+            ]
+        },
+        {
+            "role": "STEP Intern",
+            "company": "Google",
+            "dates": "Summer 2023",
+            "location": "Sunnyvale, California USA",
+            "responsibilities": [
+                "Optimized internal database processes with C++ and SQL, reducing runtime by 66% and enhancing data visualization through real-time dashboards and dynamic graphs."
+            ]
+        },
+        {
+            "role": "Robots in the Real World Researcher",
+            "company": "Oregon State University",
+            "dates": "Summer 2022",
+            "location": "Corvallis, Oregon USA",
+            "responsibilities": [
+                "Developed geometric features for multi-robot expressive motion, integrating performing arts techniques to enhance robot character and intelligence."
+            ]
+        }
+    ]
+    return render_template(
+        'index.html',
+        title="MLH Fellow",
+        url=os.getenv("URL"),
+        user=user,
+        work_experiences=work_experiences
+    )

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,37 @@
+work_experiences = [
+    {
+        "role": "Production Engineering Fellow",
+        "company": "Meta x MLH",
+        "dates": "Summer 2025",
+        "location": "Remote USA",
+        "responsibilities": []
+    },
+    {
+        "role": "Robotics Institute Summer Scholar",
+        "company": "Carnegie Mellon University",
+        "dates": "Summer 2024",
+        "location": "Pittsburgh, Pennsylvania USA",
+        "responsibilities": [
+            "Developed hierarchical reward learning systems leveraging Bayesian inference and human feedback to align autonomous systems with human preferences and improve adaptability in dynamic settings."
+        ]
+    },
+    {
+        "role": "STEP Intern",
+        "company": "Google",
+        "dates": "Summer 2023",
+        "location": "Sunnyvale, California USA",
+        "responsibilities": [
+            "Optimized internal database processes with C++ and SQL, reducing runtime by 66%.",
+            "Enhanced data visualization through real-time dashboards and dynamic graphs."
+        ]
+    },
+    {
+        "role": "Robots in the Real World Researcher",
+        "company": "Oregon State University",
+        "dates": "Summer 2022",
+        "location": "Corvallis, Oregon USA",
+        "responsibilities": [
+            "Developed geometric features for multi-robot expressive motion, integrating performing arts techniques to enhance robot character and intelligence."
+        ]
+    }
+]

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -95,3 +95,21 @@ body {
     font-size: 50px;
     font-weight: 700;
 }
+
+.work-experience {
+    max-width: 700px;
+    margin: 2rem auto;
+    padding: 1rem;
+    background: #f4f4f4;
+    border-radius: 8px;
+}
+.job {
+    margin-bottom: 1.5rem;
+}
+.job h3 {
+    margin-bottom: 0.2rem;
+}
+.job .job-dates {
+    margin: 0 0 0.5rem 0;
+    color: #666;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -60,13 +60,12 @@
         </p>
     </section>
 
-    <section class="work-experience" style="max-width:700px; margin:2rem auto; padding:1rem; background:#f4f4f4; border-radius:8px;">
+    <section class="work-experience">
         <h2>Work Experience</h2>
         {% for job in work_experiences %}
-        <div class="job" style="margin-bottom:1.5rem;">
-            <h3 style="margin-bottom:0.2rem;">{{ job.role }} — <span style="font-weight:normal;">{{ job.company }}</span>
-            </h3>
-            <p style="margin:0 0 0.5rem 0; color:#666;">{{ job.dates }} | {{ job.location }}</p>
+        <div class="job">
+            <h3>{{ job.role }} — <span style="font-weight:normal;">{{ job.company }}</span></h3>
+            <p class="job-dates">{{ job.dates }} | {{ job.location }}</p>
             {% if job.responsibilities %}
             <ul>
                 {% for responsibility in job.responsibilities %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -59,6 +59,24 @@
             Please feel free to reach out about research, collaboration, or any advice I can help with!
         </p>
     </section>
+
+    <section class="work-experience" style="max-width:700px; margin:2rem auto; padding:1rem; background:#f4f4f4; border-radius:8px;">
+        <h2>Work Experience</h2>
+        {% for job in work_experiences %}
+        <div class="job" style="margin-bottom:1.5rem;">
+            <h3 style="margin-bottom:0.2rem;">{{ job.role }} — <span style="font-weight:normal;">{{ job.company }}</span>
+            </h3>
+            <p style="margin:0 0 0.5rem 0; color:#666;">{{ job.dates }} | {{ job.location }}</p>
+            {% if job.responsibilities %}
+            <ul>
+                {% for responsibility in job.responsibilities %}
+                <li>{{ responsibility }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </section>
 </body>
 
 </html>


### PR DESCRIPTION
This pull request adds a "Work Experience" section to the homepage. It lists my prior jobs and internships, including role title, company, dates, location, and responsibilities. The section is rendered using a Jinja template loop for clean and maintainable code.
Closes #3.

Please review and let me know if any changes are needed!