### PR TITLE
Add dynamic education section with Jinja loop

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template
 import os
-from .data import work_experiences, hobbies  # Import hobbies
+from .data import work_experiences, hobbies, education  # Import education
 
 app = Flask(__name__)
 
@@ -13,7 +13,9 @@ def index():
         title="MLH Fellow",
         url=os.getenv("URL"),
         user=user,
-        work_experiences=work_experiences
+        work_experiences=work_experiences,
+        hobbies=hobbies,
+        education=education
     )
 
 

--- a/app/data.py
+++ b/app/data.py
@@ -53,3 +53,21 @@ hobbies = [
         "description": "I play both indoor and beach volleyball to stay active and have fun."
     }
 ]
+
+education = [
+    {
+        "school": "Washington State University, Honors College",
+        "years": "2021–2025",
+        "degree": "B.S. in Computer Science, Minor in Mathematics (Summa Cum Laude)",
+        "location": "Pullman, Washington USA",
+        "gpa": "GPA 3.94",
+        "details": [
+            # "Graduated with honors, focusing on AI, machine learning, and mathematics.",
+            # "Capstone Project: Retrieval-Augmented Generation (RAG) using Knowledge Graphs and Vector Search",
+            # "Honors College",
+            # "NIH MARC Fellow",
+            # "ESTEEMED MIRA Scholar",
+            # "VCEA College Ambassador"
+        ]
+    }
+]

--- a/app/data.py
+++ b/app/data.py
@@ -62,12 +62,12 @@ education = [
         "location": "Pullman, Washington USA",
         "gpa": "GPA 3.94",
         "details": [
-            # "Graduated with honors, focusing on AI, machine learning, and mathematics.",
-            # "Capstone Project: Retrieval-Augmented Generation (RAG) using Knowledge Graphs and Vector Search",
-            # "Honors College",
-            # "NIH MARC Fellow",
-            # "ESTEEMED MIRA Scholar",
-            # "VCEA College Ambassador"
+            "Graduated with honors, focusing on AI, machine learning, and mathematics.",
+            "Capstone Project: Retrieval-Augmented Generation (RAG) using Knowledge Graphs and Vector Search",
+            "Honors College",
+            "NIH MARC Fellow",
+            "ESTEEMED MIRA Scholar",
+            "VCEA College Ambassador"
         ]
     }
 ]

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -176,3 +176,28 @@ body {
 .main-container {
     margin-top: 0;
 }
+
+.education-section {
+    max-width: 700px;
+    margin: 2rem auto;
+    padding: 1rem;
+    background: #f9f9f9;
+    border-radius: 8px;
+}
+.education-list {
+    list-style: none;
+    padding: 0;
+}
+.education-item {
+    margin-bottom: 1.5rem;
+    font-size: 1.1rem;
+}
+.education-year {
+    color: #666;
+    font-size: 0.95rem;
+}
+.education-item ul {
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+    padding-left: 1.2rem;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -77,6 +77,25 @@
         </div>
         {% endfor %}
     </section>
+
+    <section class="education-section">
+        <h2>Education</h2>
+        <ul class="education-list">
+            {% for edu in education %}
+            <li class="education-item">
+                <strong>{{ edu.school }}</strong> <span class="education-year">({{ edu.years }})</span><br>
+                {{ edu.degree }}<br>
+                {{ edu.location }}<br>
+                {{ edu.gpa }}<br>
+                <ul>
+                    {% for detail in edu.details %}
+                    <li>{{ detail }}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
 </body>
 
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -87,11 +87,13 @@
                 {{ edu.degree }}<br>
                 {{ edu.location }}<br>
                 {{ edu.gpa }}<br>
+                {% if edu.details %}
                 <ul>
                     {% for detail in edu.details %}
                     <li>{{ detail }}</li>
                     {% endfor %}
                 </ul>
+                {% endif %}
             </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
This pull request adds a dynamic education section to the homepage.

* Education data is stored in `data.py` and rendered using a Jinja loop for maintainability and scalability.
* The section includes school, degree, years, location, GPA, and detailed honors/achievements.
* Styling is consistent with the rest of the site.

Closes #5.